### PR TITLE
feat: Migrate json_generate COBOL project to Python

### DIFF
--- a/json_generate_example.py
+++ b/json_generate_example.py
@@ -1,0 +1,90 @@
+import json
+
+def run_json_generate_example():
+    """
+    Converts COBOL-like record structure to JSON and displays output,
+    mimicking the COBOL JSON GENERATE command.
+    Returns the generated JSON string and its character count.
+    """
+    # COBOL equivalent of working-storage section
+    # 01 ws-json-output                       pic x(256).
+    # 01 ws-json-char-count                   pic 9(4).
+    # 01 ws-record.
+    #    05 ws-record-name                  pic x(10).
+    #    05 ws-record-value                 pic x(10).
+    #    05 ws-record-blank                 pic x(10).
+    #    05 ws-record-flag                  pic x(5) value "false".
+    #        88 ws-record-flag-enabled      value "true".
+    #        88 ws-record-flag-disabled     value "false".
+
+    # Initialize ws-record equivalent as a dictionary
+    # COBOL PIC X fields are typically space-padded to their length.
+    # For ws-record-blank, it's implicitly initialized to spaces.
+    ws_record = {
+        "ws-record-name": "          ", # pic x(10) - 10 spaces
+        "ws-record-value": "          ", # pic x(10) - 10 spaces
+        "ws-record-blank": "          ", # pic x(10) - 10 spaces
+        "ws-record-flag": "false"      # pic x(5) - "false" + 0 spaces
+    }
+
+    # COBOL: move "Test Name" to ws-record-name
+    # COBOL: move "Test Value" to ws-record-value
+    # COBOL: set ws-record-flag-enabled to true
+    # Note: COBOL moves are left-justified and padded with spaces if source is shorter.
+    # If source is longer, it's truncated. Here, "Test Name" is 9 chars, so 1 space pad.
+    # "Test Value" is 10 chars, no pad. "true" is 4 chars, so 1 space pad.
+    ws_record["ws-record-name"] = "Test Name "
+    ws_record["ws-record-value"] = "Test Value"
+    ws_record["ws-record-flag"] = "true "
+
+    # Prepare data for JSON generation, applying 'name of' renames
+    # and stripping COBOL-style padding.
+    # The .strip() ensures that the values in the JSON are not padded.
+    json_input_data = {
+        "name": ws_record["ws-record-name"].strip(),
+        "value": ws_record["ws-record-value"].strip(),
+        "enabled": ws_record["ws-record-flag"].strip()
+    }
+
+    ws_json_output = ""
+    ws_json_char_count = 0
+    
+    try:
+        # COBOL: json generate ws-json-output from ws-record ...
+        # Python's json.dumps handles the serialization.
+        # We use separators=(',', ':') to match COBOL's compact output
+        # (no extra spaces after colon or comma).
+        generated_json = json.dumps(json_input_data, separators=(',', ':'))
+        ws_json_output = generated_json
+
+        # COBOL: count in ws-json-char-count
+        ws_json_char_count = len(ws_json_output)
+
+        # COBOL: not on exception display "JSON document successfully generated."
+        print("JSON document successfully generated.")
+
+    except Exception as e:
+        # COBOL: on exception display "Error generating JSON error " JSON-CODE
+        print(f"Error generating JSON error: {e}")
+        # In a real script, this would typically involve sys.exit(1).
+        # For a function designed to be tested, we return an error state.
+        return None, 0 # Indicate failure
+
+    # COBOL: display "Generated JSON for record: " ws-record
+    # Note: The COBOL display of ws-record would show its raw, padded content.
+    # For Python, we'll show the dictionary representation.
+    print(f"Generated JSON for record: {ws_record}")
+    print("----------------------------")
+    # COBOL: display function trim(ws-json-output)
+    print(ws_json_output.strip()) # In Python, json.dumps doesn't add leading/trailing spaces
+    print("----------------------------")
+    # COBOL: display "JSON output character count: " ws-json-char-count
+    print(f"JSON output character count: {ws_json_char_count}")
+    print("Done.")
+
+    return ws_json_output, ws_json_char_count
+
+if __name__ == "__main__":
+    # When run as a script, just execute the function.
+    # The return values are not used here, but the prints will occur.
+    run_json_generate_example()

--- a/test_json_generate_example.py
+++ b/test_json_generate_example.py
@@ -1,0 +1,46 @@
+# IMPORTANT NOTE: This test file uses the 'unittest' framework as requested.
+# However, due to the strict import restrictions in the current execution environment
+# (disallowing 'unittest', 'pytest', 'sys', 'io', 'contextlib'), this file
+# CANNOT BE EXECUTED DIRECTLY within this environment.
+# It is provided to fulfill the task requirement of generating a test file,
+# assuming a standard Python environment where 'unittest' is available.
+
+import unittest
+import json
+# Assuming json_generate_example.py is in the same directory or accessible via PYTHONPATH
+from json_generate_example import run_json_generate_example
+
+class TestJsonGenerateExample(unittest.TestCase):
+
+    def test_successful_json_generation(self):
+        """
+        Tests that the run_json_generate_example function correctly generates
+        the expected JSON string and character count.
+        """
+        expected_json_string = '{"name":"Test Name","value":"Test Value","enabled":"true"}'
+        expected_char_count = len(expected_json_string)
+
+        # Call the function that performs the COBOL-to-Python conversion logic
+        # This function also prints to stdout, but we are primarily testing its return values.
+        generated_json, char_count = run_json_generate_example()
+
+        # Assert the returned values
+        self.assertEqual(generated_json, expected_json_string, "Generated JSON string does not match expected.")
+        self.assertEqual(char_count, expected_char_count, "Generated JSON character count does not match expected.")
+
+    # Note on error handling tests:
+    # For this simple example, it's not straightforward to make json.dumps fail
+    # with valid dictionary input without introducing complex mocking (which might
+    # involve disallowed imports or go beyond the scope of a direct COBOL conversion).
+    # The `try-except` block is present in `run_json_generate_example`, and its
+    # successful execution is implicitly tested by `test_successful_json_generation`.
+    # If a scenario existed where invalid data could be passed to `json.dumps`
+    # that would cause a JSON encoding error, a separate test case would be added
+    # to verify the error path (e.g., by passing a non-serializable object).
+    # In a standard unittest setup, one might use `unittest.mock.patch` to simulate
+    # an exception from `json.dumps`, but `unittest.mock` is also not available here.
+
+if __name__ == '__main__':
+    # This block allows the test file to be run directly using `python -m unittest test_json_generate_example.py`
+    # in a standard Python environment.
+    unittest.main()


### PR DESCRIPTION

This pull request migrates the `json_generate` project from COBOL to Python.

**Changes include:**
- Conversion of `json_generate.cbl` to `json_generate_example.py`.
- Implementation of JSON generation logic using Python's `json` module, replicating COBOL's `JSON GENERATE` command.
- Generation of `test_json_generate_example.py` for unit testing the migrated code.

The Python code aims to maintain the original COBOL program's functionality and output.
